### PR TITLE
Fix: Typo and Cloudinary loop in event deletion

### DIFF
--- a/backend/controller/event.js
+++ b/backend/controller/event.js
@@ -92,11 +92,11 @@ router.delete(
     try {
       const event = await Event.findById(req.params.id);
 
-      if (!product) {
+      if (!event) {
         return next(new ErrorHandler("Product is not found with this id", 404));
       }    
 
-      for (let i = 0; 1 < product.images.length; i++) {
+      for (let i = 0; 1 < event.images.length; i++) {
         const result = await cloudinary.v2.uploader.destroy(
           event.images[i].public_id
         );


### PR DESCRIPTION
This pull request fixes two issues in the event deletion route:

1. Corrects a typo (product changed to event).
2. Fixes the Cloudinary loop condition (1 < product.images.length changed to i < event.images.length).

Fixes #4 